### PR TITLE
[library] Enable SlevomatCodingStandard.Namespaces.NamespaceSpacing

### DIFF
--- a/library.xml
+++ b/library.xml
@@ -87,4 +87,10 @@
 			<property name="searchAnnotations" value="true" />
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing">
+		<properties>
+			<property name="linesCountBeforeNamespace" value="1" />
+			<property name="linesCountAfterNamespace" value="1" />
+		</properties>
+	</rule>
 </ruleset>

--- a/moya.xml
+++ b/moya.xml
@@ -70,4 +70,10 @@
 			<property name="searchAnnotations" value="true" />
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing">
+		<properties>
+			<property name="linesCountBeforeNamespace" value="1" />
+			<property name="linesCountAfterNamespace" value="1" />
+		</properties>
+	</rule>
 </ruleset>


### PR DESCRIPTION
Enforce a single blank line before and after the namespace declaration

Should this be added in `moya.xml`?

Resolves #5 