### PR TITLE
[MultilineFunctionDeclaration] Make multiline in the middle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ class Example
 }
 ```
 
+Enforce multi row parameters to not be on the first row.
+Example:
+
+```php
+class Example
+{
+	public function test(
+		#[Attribute]
+		int $param
+	)
+}
+
 ### DocCommentSniff
 
 Allows some doc blocks to work as single line:

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ class Example
 {
 	public function test(
 		#[Attribute]
-		int $param
+		int $param,
 	)
 }
+```
 
 ### DocCommentSniff
 

--- a/library.xml
+++ b/library.xml
@@ -113,4 +113,5 @@
 	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
 	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
 	<rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+	<rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>
 </ruleset>

--- a/src/Stefna/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Stefna/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -48,6 +48,23 @@ final class MultiLineFunctionDeclarationSniff extends BaseSniff
 				return;
 			}
 		}
+		elseif (
+			!$tokensCollection->sameLine(
+				$tokensCollection->parenthesisOpener($stackPtr),
+				$tokensCollection->parenthesisCloser($stackPtr)
+			)
+		) {
+			$parenthesisStart = $tokensCollection->parenthesisOpener($stackPtr);
+			$nextPtr = $phpcsFile->findNext(T_WHITESPACE, $parenthesisStart + 1, exclude: true);
+
+			if ($tokensCollection->sameLine($parenthesisStart, $nextPtr)) {
+				$error = 'Multiline function declarations can not start on the first line';
+				$fix = $phpcsFile->addFixableError($error, $nextPtr, 'MultilineNotPure');
+				if ($fix) {
+					$phpcsFile->fixer->addNewline($parenthesisStart);
+				}
+			}
+		}
 
 		parent::processSingleLineDeclaration($phpcsFile, $stackPtr, $tokens);
 	}

--- a/src/Stefna/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
+++ b/src/Stefna/Sniffs/Functions/MultiLineFunctionDeclarationSniff.php
@@ -51,7 +51,7 @@ final class MultiLineFunctionDeclarationSniff extends BaseSniff
 		elseif (
 			!$tokensCollection->sameLine(
 				$tokensCollection->parenthesisOpener($stackPtr),
-				$tokensCollection->parenthesisCloser($stackPtr)
+				$tokensCollection->parenthesisCloser($stackPtr),
 			)
 		) {
 			$parenthesisStart = $tokensCollection->parenthesisOpener($stackPtr);

--- a/tests/Sniffs/Functions/MultiLineFunctionDeclarationSniffTest.php
+++ b/tests/Sniffs/Functions/MultiLineFunctionDeclarationSniffTest.php
@@ -22,4 +22,13 @@ class MultiLineFunctionDeclarationSniffTest extends TestCase
 
 		self::assertAllFixedInFile('OK');
 	}
+
+	public function testMultilineDeclaration(): void
+	{
+		$this->checkFile('MultilineDeclaration');
+
+		self::assertSniffError('MultilineNotPure', line: 7);
+
+		self::assertAllFixedInFile();
+	}
 }

--- a/tests/Sniffs/Functions/data/MultiLineFunctionDeclarationSniff/MultilineDeclaration.fixed.php
+++ b/tests/Sniffs/Functions/data/MultiLineFunctionDeclarationSniff/MultilineDeclaration.fixed.php
@@ -6,7 +6,7 @@ class MultilineDeclaration
 {
 	public function setFoo(
 		#[Beep]
-		Foo $new
+		Foo $new,
 	): void {
 	}
 }

--- a/tests/Sniffs/Functions/data/MultiLineFunctionDeclarationSniff/MultilineDeclaration.fixed.php
+++ b/tests/Sniffs/Functions/data/MultiLineFunctionDeclarationSniff/MultilineDeclaration.fixed.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace StefnaTest\Sniffs\Functions\data\MultiLineFunctionDeclarationSniff;
+
+class MultilineDeclaration
+{
+	public function setFoo(
+		#[Beep]
+		Foo $new
+	): void {
+	}
+}

--- a/tests/Sniffs/Functions/data/MultiLineFunctionDeclarationSniff/MultilineDeclaration.php
+++ b/tests/Sniffs/Functions/data/MultiLineFunctionDeclarationSniff/MultilineDeclaration.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace StefnaTest\Sniffs\Functions\data\MultiLineFunctionDeclarationSniff;
+
+class MultilineDeclaration
+{
+	public function setFoo(#[Beep]
+	Foo $new): void
+	{}
+}

--- a/tests/Sniffs/Functions/data/MultiLineFunctionDeclarationSniff/MultilineDeclaration.php
+++ b/tests/Sniffs/Functions/data/MultiLineFunctionDeclarationSniff/MultilineDeclaration.php
@@ -5,6 +5,6 @@ namespace StefnaTest\Sniffs\Functions\data\MultiLineFunctionDeclarationSniff;
 class MultilineDeclaration
 {
 	public function setFoo(#[Beep]
-	Foo $new): void
+	Foo $new,): void
 	{}
 }

--- a/tests/Sniffs/GeneralCodeStyle/FormattingTest.php
+++ b/tests/Sniffs/GeneralCodeStyle/FormattingTest.php
@@ -12,4 +12,11 @@ class FormattingTest extends TestCase
 
 		self::assertAllFixedInFile(skipErrorCheck: true);
 	}
+
+	public function testAttributeMethodDeclaration(): void
+	{
+		$this->checkFile('AttributeMethodDeclaration');
+
+		self::assertAllFixedInFile(skipErrorCheck: true);
+	}
 }

--- a/tests/Sniffs/GeneralCodeStyle/data/Formatting/AttributeMethodDeclaration.fixed.php
+++ b/tests/Sniffs/GeneralCodeStyle/data/Formatting/AttributeMethodDeclaration.fixed.php
@@ -6,7 +6,7 @@ class X
 {
 	public function setFoo(
 		#[Beep]
-		Foo $new
+		Foo $new,
 	): void {
 	}
 }

--- a/tests/Sniffs/GeneralCodeStyle/data/Formatting/AttributeMethodDeclaration.fixed.php
+++ b/tests/Sniffs/GeneralCodeStyle/data/Formatting/AttributeMethodDeclaration.fixed.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace StefnaTest\Sniffs\GeneralCodeStyle\data\Formatting;
+
+class X
+{
+	public function setFoo(
+		#[Beep]
+		Foo $new
+	): void {
+	}
+}

--- a/tests/Sniffs/GeneralCodeStyle/data/Formatting/AttributeMethodDeclaration.php
+++ b/tests/Sniffs/GeneralCodeStyle/data/Formatting/AttributeMethodDeclaration.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace StefnaTest\Sniffs\GeneralCodeStyle\data\Formatting;
+
+class X
+{
+	public function setFoo(#[Beep] Foo $new): void
+	{
+	}
+}


### PR DESCRIPTION
If a function is having multiple rows in the parameters, then nothing can be on the first row.

POC for #18 