### PR TITLE
[library] Add SlevomatCodingStandard.Classes.ClassLength rule

### DIFF
--- a/library.xml
+++ b/library.xml
@@ -87,4 +87,5 @@
 			<property name="searchAnnotations" value="true" />
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.ClassLength"/>
 </ruleset>

--- a/moya.xml
+++ b/moya.xml
@@ -70,4 +70,5 @@
 			<property name="searchAnnotations" value="true" />
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.ClassLength"/>
 </ruleset>


### PR DESCRIPTION
Found 10 errors (Max file length is 351 lines, while limit for this is 250)