### PR TITLE
[library] Add trailing comma rules for call and declare

### DIFF
--- a/library.xml
+++ b/library.xml
@@ -109,4 +109,6 @@
 	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
 	<rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
+	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
+	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
 </ruleset>

--- a/moya.xml
+++ b/moya.xml
@@ -85,4 +85,6 @@
 	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
 	<rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/>
+	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
+	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
 </ruleset>

--- a/tests/Sniffs/GeneralCodeStyle/data/Formatting/Formatting.fixed.php
+++ b/tests/Sniffs/GeneralCodeStyle/data/Formatting/Formatting.fixed.php
@@ -27,3 +27,8 @@ class X
 		echo 'Z';
 	}
 }
+
+random_int(
+	0,
+	1,
+);

--- a/tests/Sniffs/GeneralCodeStyle/data/Formatting/Formatting.php
+++ b/tests/Sniffs/GeneralCodeStyle/data/Formatting/Formatting.php
@@ -9,7 +9,7 @@ class X
 	public function __construct(
 		public int $y = 53,
 
-		public bool $q = true,
+		public bool $q = true
 	) {}
 
 
@@ -31,3 +31,8 @@ class X
 
 	}
 }
+
+random_int(
+	0,
+	1
+);


### PR DESCRIPTION
SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration SlevomatCodingStandard.Functions.RequireTrailingCommaInCall


This is intended to be used instead of #15 