### PR TITLE
[sniffs, blanlinessniff] Remove Symbol skip

### DIFF
--- a/src/Stefna/Sniffs/Functions/BlankLinesSniff.php
+++ b/src/Stefna/Sniffs/Functions/BlankLinesSniff.php
@@ -104,7 +104,7 @@ final class BlankLinesSniff implements Sniff
 
 	private function firstOnNextLine(File $phpcsFile, int $stackPtr, TokenCollection $tokens): int
 	{
-		$next = $stackPtr + 1;
+		$next = $stackPtr;
 		do {
 			$next = $phpcsFile->findNext(T_WHITESPACE, $next + 1, exclude: true);
 		}

--- a/tests/Sniffs/Functions/BlankLinesSniffTest.php
+++ b/tests/Sniffs/Functions/BlankLinesSniffTest.php
@@ -25,4 +25,11 @@ class BlankLinesSniffTest extends TestCase
 
 		self::assertAllFixedInFile();
 	}
+
+	public function testComment(): void
+	{
+		$this->checkFile('Comments');
+
+		self::assertNoSniffErrorInFile();
+	}
 }

--- a/tests/Sniffs/Functions/data/BlankLinesSniff/Comments.php
+++ b/tests/Sniffs/Functions/data/BlankLinesSniff/Comments.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace StefnaTest\Sniffs\Functions\data\BlankLinesSniff;
+
+class ClassMethods
+{
+	public function test(): bool
+	{
+		var_dump(
+			1,
+		);
+
+		/*
+		$table->createForeignKey(
+			$author,
+			new ForeignReference(Accounts::NAME, 'id'),
+			onDelete: ForeignAction::Cascade,
+			onUpdate: ForeignAction::Cascade,
+		);
+		 */
+
+		return false;
+	}
+}


### PR DESCRIPTION
Removed symbol skip when staring on a new line, as the assumption it would always be a whitespace, but with comments it's part of the ending comment token, even when indented.